### PR TITLE
Allow repeated command entries when in "Special Menu" by not clearing "SelectedDirectory".

### DIFF
--- a/Marlin/AnycubicTFT.cpp
+++ b/Marlin/AnycubicTFT.cpp
@@ -903,7 +903,9 @@ void AnycubicTFTClass::GetCommandFromTFT()
           }
           case 8: // A8 GET  SD LIST
             #ifdef SDSUPPORT
-              SelectedDirectory[0]=0;
+              if (!SpecialMenu)
+                SelectedDirectory[0]=0;
+                
               if(!IS_SD_INSERTED())
               {
                 ANYCUBIC_SERIAL_PROTOCOLPGM("J02");
@@ -985,7 +987,8 @@ void AnycubicTFTClass::GetCommandFromTFT()
                 } else if (TFTstrchr_pointer[4] == '<') {
                   strcpy(SelectedDirectory, TFTstrchr_pointer+4);
                 } else {
-                  SelectedDirectory[0]=0;
+                  if (!SpecialMenu)
+                    SelectedDirectory[0]=0;
 
                   if(starpos!=NULL)
                   *(starpos-1)='\0';
@@ -1211,7 +1214,8 @@ void AnycubicTFTClass::GetCommandFromTFT()
                 }
               }
 
-              SelectedDirectory[0]=0;
+              if (!SpecialMenu)
+                SelectedDirectory[0]=0;
 
               if(!IS_SD_INSERTED())
               {


### PR DESCRIPTION
This is a small change to allow repeated commands from the Special Menu. E.g. using this, you can repeatedly send <Z Up 0.1> while performing mesh level. Way more convenient than having to reselect the command.