### PR TITLE
Enable M33 command

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -697,10 +697,10 @@
   #endif
 
   // This allows hosts to request long names for files and folders with M33
-  //#define LONG_FILENAME_HOST_SUPPORT
+  #define LONG_FILENAME_HOST_SUPPORT
 
   // Enable this option to scroll long filenames in the SD card menu
-  //#define SCROLL_LONG_FILENAMES
+  #define SCROLL_LONG_FILENAMES
 
   /**
    * This option allows you to abort SD printing when any endstop is triggered.


### PR DESCRIPTION
Enable M33 with 65 chars max filename length

Since enabling only the `LONG_FILENAME_HOST_SUPPORT` gives a max filename length of 26 chars i also enabled `SCROLL_LONG_FILENAMES` to boost the max length to 65 chars. This is good because the Octoprint plugin Long Path SD LIST get only complete filenames, so if a filename is truncated it dosen't show it.

Tested on my i3 Mega-S and works without problems